### PR TITLE
Add slug instead of id for mentionables

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -15,8 +15,8 @@ $(document).ready(function() {
   $('.input-mentionable').atwho({
     at: '@',
     data: $('#mentionable-data').data('content'),
-    insertTpl: '<a href="/users/${id}">${name}</a>',
-    displayTpl: '<li data-id="${id}"><span>${name}</span></li>',
+    insertTpl: '<a href="/users/${slug}">${name}</a>',
+    displayTpl: '<li data-slug="${slug}"><span>${name}</span></li>',
     limit: 15
   });
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,7 +32,7 @@ class UsersController < ApplicationController
   end
 
   def mentionable
-    render json: @user.following_users.as_json(only: [:id, :name]), root: false
+    render json: @user.following_users.as_json(only: [:slug, :name]), root: false
   end
 
   def photo_albums


### PR DESCRIPTION
- Change from id to slug in mentionable.
- Post content uses the User slug instead of the id